### PR TITLE
ci: log into ghcr prior to pushing

### DIFF
--- a/.github/workflows/push-pr-release.yaml
+++ b/.github/workflows/push-pr-release.yaml
@@ -8,6 +8,9 @@ on:
 
 jobs:
   build-contianer:
+    permissions:
+      contents: read
+      packages: write
     name: Build container
     runs-on: ubuntu-latest
     steps:
@@ -25,6 +28,13 @@ jobs:
         uses: docker/setup-qemu-action@v3
       - name: Set up Docker Buildx
         uses: docker/setup-buildx-action@v3
+      - name: Log into ghcr.io
+        if: github.event_name == 'push'
+        uses: docker/login-action@v3
+        with:
+          registry: ghcr.io
+          username: ${{ github.actor }}
+          password: ${{ secrets.GITHUB_TOKEN }}
       - name: Build and push
         uses: docker/build-push-action@v6
         with:


### PR DESCRIPTION
Turns out you need this before being able to push, who knew.