### PR TITLE
renovate: fix version template extracting for chromium-swiftshader

### DIFF
--- a/.github/renovate.json5
+++ b/.github/renovate.json5
@@ -44,7 +44,7 @@
       // We use two different datasources for main and community, as alpine serves them in different URLs.
       "datasourceTemplate": "custom.alpine-community",
       // Extracted "versions" include the package name, so here we strip that prefix using a regex.
-      "extractVersionTemplate": "{{depName}}-(?<version>.+).apk",
+      "extractVersionTemplate": "chromium-swiftshader-(?<version>.+).apk",
     },
   ]
 }

--- a/Dockerfile
+++ b/Dockerfile
@@ -4,5 +4,5 @@ ARG ALPINE_VERSION=3.20.3@sha256:1e42bbe2508154c9126d48c2b8a75420c3544343bf86fd0
 FROM alpine:${ALPINE_VERSION}
 
 # Renovate and CI/CD interact with the following line. Keep its format as it is.
-ARG CHROMIUM_VERSION=131.0.6778.69-r0
+ARG CHROMIUM_VERSION=131.0.6778.85-r0
 RUN apk add --no-cache "chromium-swiftshader=${CHROMIUM_VERSION}"


### PR DESCRIPTION
Previous template worked with the dynamic package capture, but if we hardcode `depName` it seems we have to hardcode this as well.