### PR TITLE
ci: tag using chromiumversion-alpineversion instead of the opposite

### DIFF
--- a/.github/workflows/push-pr-release.yaml
+++ b/.github/workflows/push-pr-release.yaml
@@ -41,4 +41,4 @@ jobs:
           push: ${{ github.event_name == 'push' }}
           platforms: linux/amd64,linux/arm64
           tags: |-
-            ghcr.io/${{ github.repository }}:${{ steps.repo.outputs.alpine_version }}-${{ steps.repo.outputs.chromium_version }}
+            ghcr.io/${{ github.repository }}:${{ steps.repo.outputs.chromium_version }}-${{ steps.repo.outputs.alpine_version }}


### PR DESCRIPTION
Rationale being that I think this image is more "chromium based on alpine" than "alpine with chromium". Putting the chromium version first reflects this by making it more relevant.