### PR TITLE
renovate: disable dependency dashboard

### DIFF
--- a/.github/renovate.json5
+++ b/.github/renovate.json5
@@ -3,6 +3,7 @@
   "extends": [
     "config:best-practices",
     ":semanticCommitsDisabled",
+    ":disableDependencyDashboard",
     "github>grafana/sm-renovate//presets/grafana.json5",
     "github>grafana/sm-renovate//presets/alpine-packages.json5"
   ],


### PR DESCRIPTION
For some reason this seems to be buggy, and it is creating a new `Dependency dashboard` issue for every renovate run. Given that this repo only has two dependencies, it doesn't seem very valuable either.