### PR TITLE
renovate: automerge updates to Dockerfile

### DIFF
--- a/.github/renovate.json5
+++ b/.github/renovate.json5
@@ -16,6 +16,9 @@
         "Dockerfile"
       ],
       "groupName": "Dockerfile",
+      // Allow renovate to automatically merge PRs created for these packages. Renovate automatically checks CI/CD
+      // status and will _not_ automerge PRs which have failures.
+      "automerge": true,
     },
   ],
   "customManagers": [


### PR DESCRIPTION
Together with release-on-main-push, this should make most of this repo maintenance free, other than updating actions.