### PR TITLE
fix: increase `timeout-minutes` to 10

### DIFF
--- a/.github/workflows/renovate.yaml
+++ b/.github/workflows/renovate.yaml
@@ -15,7 +15,7 @@ jobs:
       contents: read
       id-token: write
     runs-on: ubuntu-latest
-    timeout-minutes: 5
+    timeout-minutes: 10
     steps:
       - name: Checkout Code
         uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2


### PR DESCRIPTION
5 does not seem to be enough, e.g.
https://github.com/grafana/sm-renovate/actions/runs/15243753777/job/42867221405?pr=576