### PR TITLE
chore: security: temporarily move to alpine edge and chromium 137.0.7151.103-r0

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,10 +1,10 @@
 # Renovate and CI/CD interact with the following line. Keep its format as it is.
-ARG ALPINE_VERSION=3.22.0@sha256:8a1f59ffb675680d47db6337b49d22281a139e9d709335b492be023728e11715
+ARG ALPINE_VERSION=edge
 
 FROM alpine:${ALPINE_VERSION}
 
 RUN apk add --no-cache font-noto font-noto-cjk
 
 # Renovate and CI/CD interact with the following line. Keep its format as it is.
-ARG CHROMIUM_VERSION=137.0.7151.68-r0
+ARG CHROMIUM_VERSION=137.0.7151.103-r0
 RUN apk add --no-cache "chromium-swiftshader=${CHROMIUM_VERSION}"


### PR DESCRIPTION
Temporarily moving to edge to mitigate CVE-2025-5959.