### PR TITLE
chore: revert moving to edge

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,10 +1,10 @@
 # Renovate and CI/CD interact with the following line. Keep its format as it is.
-ARG ALPINE_VERSION=edge
+ARG ALPINE_VERSION=3.22.0@sha256:8a1f59ffb675680d47db6337b49d22281a139e9d709335b492be023728e11715
 
 FROM alpine:${ALPINE_VERSION}
 
 RUN apk add --no-cache font-noto font-noto-cjk
 
 # Renovate and CI/CD interact with the following line. Keep its format as it is.
-ARG CHROMIUM_VERSION=137.0.7151.103-r0
+ARG CHROMIUM_VERSION=137.0.7151.68-r0
 RUN apk add --no-cache "chromium-swiftshader=${CHROMIUM_VERSION}"


### PR DESCRIPTION
This reverts commit 9e354b9cb476bafd7938dbd1470c3f409c1624cf.

Said commit was merged for CI/CD to produce a release with a patched version of chromium for CVE-2025-5959, which at the time of writing is only available on alpine edge.

The release has been produced and we should go back to stable, as staying on edge will prevent renovate from creating chromium updates.