### PR TITLE
chore: Update dependency chromium-swiftshader to 140.0.7339.127-r0

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -6,5 +6,5 @@ FROM alpine:${ALPINE_VERSION}
 RUN apk add --no-cache font-noto font-noto-cjk
 
 # Renovate and CI/CD interact with the following line. Keep its format as it is.
-ARG CHROMIUM_VERSION=139.0.7258.154-r0
+ARG CHROMIUM_VERSION=140.0.7339.127-r0
 RUN apk add --no-cache "chromium-swiftshader=${CHROMIUM_VERSION}"


### PR DESCRIPTION
Update chromium-swiftshader to 140.0.7339.127-r0 to fix CVE-2025-4574