### PR TITLE
Add AGENTS.md and symlinked CLAUDE.md

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,0 +1,11 @@
+# chromium-swiftshader-alpine
+
+Alpine container image providing headless Chromium with SwiftShader for downstream browser testing.
+
+## Architecture
+
+Three systems parse the Dockerfile ARG lines independently: Renovate custom regex managers extract versions to check for updates, CI greps the same lines to compose the image tag, and Docker uses them at build time. All three must agree on the line format.
+
+## Gotchas
+
+Alpine and Chromium versions must be bumped together. A Chromium package version that exists for one Alpine release may not exist for another, so splitting them into separate changes causes builds that fail only at install time with a cryptic package-not-found error.

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1,0 +1,1 @@
+AGENTS.md


### PR DESCRIPTION
## What?

Adds AGENTS.md (agent context file) and CLAUDE.md (symlink to AGENTS.md) to this repo.

## Why?

Part of the k6-core AGENTS.md rollout (grafana/k6#5780). Coding agents read this file to orient themselves in a repo: architecture overview, build commands, gotchas. Without it, agents waste tokens on trial-and-error exploration.

AGENTS.md is vendor-neutral. CLAUDE.md is a symlink to it, so Claude-based tools pick it up too.

## Note

This is a starting point, auto-generated from repo exploration. Please review and update with repo-specific preferences.

## Related PR(s)/Issue(s)

Part of grafana/k6#5780