### PR TITLE
fix: Update chromium-swiftshader to 148.0.7778.167-r0

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -6,7 +6,7 @@ FROM alpine:${ALPINE_VERSION}
 RUN apk add --no-cache font-noto font-noto-cjk
 
 # Renovate and CI/CD interact with the following line. Keep its format as it is.
-ARG CHROMIUM_VERSION=148.0.7778.96-r0
+ARG CHROMIUM_VERSION=148.0.7778.167-r0
 RUN apk add --no-cache "chromium=${CHROMIUM_VERSION}" "chromium-swiftshader=${CHROMIUM_VERSION}"
 
 # Build time check, asserting chromium binary is installed and sane

--- a/README.md
+++ b/README.md
@@ -11,3 +11,18 @@ FROM ghcr.io/grafana/chromium-swiftshader-alpine:000.0.0000.00-r0-0.0.0@sha256:e
 ```
 
 That way, dependency bumping bots will create PRs when the tag is overwritten.
+
+## Updating the Chrome version
+
+Renovate is set up to update [the Chrome version used to build the container
+image](Dockerfile).
+
+Should that process fail for some reason, you can verify [the version currently
+available from the Alpine community repository][alpine-search]. Notice the
+branch might need to be adjusted to reflect what's current. Notice as well that
+currently we use `chromium-swiftshader`, **not** `chromium`.
+
+Should there ever be a need to update this version by hand, update the
+[Dockerfile](Dockerfile) and create a new release.
+
+[alpine-search]: https://pkgs.alpinelinux.org/packages?name=chromium-swiftshader&branch=v3.23&repo=&arch=x86_64&origin=&flagged=&maintainer=


### PR DESCRIPTION
This closes [a number][chrome-update-1] [of CVEs][chrome-update-2] that we care about.

[chrome-update]: https://chromereleases.googleblog.com/2026/04/stable-channel-update-for-desktop_28.html
[chrome-update-2]: https://chromereleases.googleblog.com/2026/05/stable-channel-update-for-desktop_12.html