### PR TITLE
fix: Update chromium-swiftshader to 148.0.7778.178-r0

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -6,7 +6,7 @@ FROM alpine:${ALPINE_VERSION}
 RUN apk add --no-cache font-noto font-noto-cjk
 
 # Renovate and CI/CD interact with the following line. Keep its format as it is.
-ARG CHROMIUM_VERSION=148.0.7778.167-r0
+ARG CHROMIUM_VERSION=148.0.7778.178-r0
 RUN apk add --no-cache "chromium=${CHROMIUM_VERSION}" "chromium-swiftshader=${CHROMIUM_VERSION}"
 
 # Build time check, asserting chromium binary is installed and sane


### PR DESCRIPTION
This update addresses a number of [CVEs](https://chromereleases.googleblog.com/2026/05/stable-channel-update-for-desktop_0841193308.html) 

[Alpine package ](https://pkgs.alpinelinux.org/package/v3.23/community/x86_64/chromium-swiftshader)