### PR TITLE
Replace core with cloud-engine as codeowners

### DIFF
--- a/CODEOWNERS
+++ b/CODEOWNERS
@@ -1,4 +1,4 @@
 # https://help.github.com/articles/about-codeowners/
 # https://git-scm.com/docs/gitignore#_pattern_format
 
-* @grafana/synthetic-monitoring-dev @grafana/k6-core
+* @grafana/synthetic-monitoring-dev @grafana/k6-cloud-engine


### PR DESCRIPTION
the k6 core team doesn't use this and AFAIK hasn't in  some time. 

There is no point in us revieweing stuff that we won't later maintain and rubber sstamping it.

GCk6 still runs this but this is in k6-cloud-engine domain.

CC @Lantero