### PR TITLE
fix: Update chromium-swiftshader to 149.0.7827.53-r0

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -6,7 +6,7 @@ FROM alpine:${ALPINE_VERSION}
 RUN apk add --no-cache font-noto font-noto-cjk
 
 # Renovate and CI/CD interact with the following line. Keep its format as it is.
-ARG CHROMIUM_VERSION=148.0.7778.178-r0
+ARG CHROMIUM_VERSION=149.0.7827.53-r0
 RUN apk add --no-cache "chromium=${CHROMIUM_VERSION}" "chromium-swiftshader=${CHROMIUM_VERSION}"
 
 # Build time check, asserting chromium binary is installed and sane


### PR DESCRIPTION
Alpine 3.23 no longer ships the pinned `148.0.7778.178-r0` chromium package — its repo now only offers `149.0.7827.53-r0`. 

Changes in the new version: https://github.com/grafana/chromium-swiftshader-alpine/pull/172