### PR TITLE
fix: bump Alpine to 3.24.1 and Chromium to 150.0.7871.181-r0 together

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,12 +1,12 @@
 # Renovate and CI/CD interact with the following line. Keep its format as it is.
-ARG ALPINE_VERSION=3.23.4@sha256:5b10f432ef3da1b8d4c7eb6c487f2f5a8f096bc91145e68878dd4a5019afde11
+ARG ALPINE_VERSION=3.24.1@sha256:28bd5fe8b56d1bd048e5babf5b10710ebe0bae67db86916198a6eec434943f8b
 
 FROM alpine:${ALPINE_VERSION}
 
 RUN apk add --no-cache font-noto font-noto-cjk
 
 # Renovate and CI/CD interact with the following line. Keep its format as it is.
-ARG CHROMIUM_VERSION=149.0.7827.53-r0
+ARG CHROMIUM_VERSION=150.0.7871.181-r0
 RUN apk add --no-cache "chromium=${CHROMIUM_VERSION}" "chromium-swiftshader=${CHROMIUM_VERSION}"
 
 # Build time check, asserting chromium binary is installed and sane


### PR DESCRIPTION
Supersedes #173, which has been approved but red since 2026-06-19.

## Why #173 fails

#173 bumps `ALPINE_VERSION` alone. Alpine 3.24 does not carry
`chromium-149.0.7827.53-r0`, so the pin becomes unresolvable:

```
#9 [linux/amd64 3/4] RUN apk add --no-cache "chromium=149.0.7827.53-r0" "chromium-swiftshader=149.0.7827.53-r0"
ERROR: unable to select packages:
  chromium-149.0.7827.155-r0:
    breaks: world[chromium=149.0.7827.53-r0]
```

This is the failure mode `AGENTS.md` already documents — the two ARGs are
coupled and must move in the same commit. Renovate proposes them as separate
updates, so the Alpine PR is always born red.

## This PR

Both ARG lines move together, formats preserved (Renovate regex managers, the
CI tag grep, and Docker all parse them):

- `ALPINE_VERSION`: `3.23.4` → `3.24.1` (same digest #173 used)
- `CHROMIUM_VERSION`: `149.0.7827.53-r0` → `150.0.7871.181-r0`

`chromium` and `chromium-swiftshader` are both at `150.0.7871.181-r0` in the
v3.24 community repo for **x86_64 and aarch64**, so the multi-arch build is
satisfied.

Verified locally (`docker build --platform linux/amd64`):

```
#7 23.12 (173/174) Installing chromium (150.0.7871.181-r0)
#7 35.60 (174/174) Installing chromium-swiftshader (150.0.7871.181-r0)
#8 [4/4] RUN chromium --version
#8 0.632 Chromium 150.0.7871.181 Alpine Linux
```

Resulting tag: `150.0.7871.181-r0-3.24.1`.

## Security impact

`grafanalabs-global/docker-k6-cloud-browser-docker-prod/k6-browser-docker`
(built `FROM` this image) currently reports **10 CRITICAL + 69 HIGH** active
CVEs in vuln-o11y, and every affected package is either upgraded or dropped
here. Installed-version diff, old base vs. this build:

| Package | 3.23.4 / chromium 149 | 3.24.1 / chromium 150 |
| --- | --- | --- |
| chromium, chromium-swiftshader | 149.0.7827.53-r0 | 150.0.7871.181-r0 |
| ffmpeg-libav{codec,format,util}, libswresample | 8.0.1-r1 | 8.1.2-r0 |
| glib | 2.86.3-r0 | 2.88.1-r1 |
| libssh | 0.11.4-r0 | 0.12.1-r0 |
| sqlite-libs | 3.51.2-r0 | 3.53.2-r0 |
| cups-libs | 2.4.18-r0 | 2.4.19-r0 |
| libjxl | 0.11.2-r0 | 0.11.2-r1 |
| python3 | 3.12.13-r0 | **no longer installed** |
| tiff | 4.7.1-r0 | **no longer installed** |

Confirmed against published fix versions:

- 7 CRITICAL Chromium CVEs (CVE-2026-15899/15900/15901/16419/16424/16414/16416,
  CVSS 9.3–9.6) and ~33 HIGH — advisories cite fixes in 150.0.7871.x.
- CVE-2026-40962 (ffmpeg, CVSS 9.8) — fixed version is `8.1`; this ships 8.1.2.
- CVE-2026-6100 (python3, CVSS 9.1) and the tiff HIGHs — packages are gone.

`glib` (CVE-2026-58016, 9.1), `libssh`, `sqlite-libs` and `cups-libs` advance
past their reported-vulnerable versions but Alpine publishes no explicit
`fixed_version` for them, so treat those as expected-fixed pending a rescan.

## Reviewer notes

Two changes deserve a look beyond the version strings:

- **Alpine 3.23 → 3.24 is a distro upgrade**, not a patch bump.
- **Chromium 149 → 150 is a browser-behaviour change** for every downstream
  consumer, not just a security patch. Worth a smoke test in Synthetic
  Monitoring and in `grafana/k6-cloud-browser-docker` (`run_test.bats`) before
  release.

Found while running caretaker duty on the k6 repos; happy to hand this over if
Synthetic Monitoring would rather drive it.
