### PR TITLE
fix: unblock renovate chromium updates

### DIFF
--- a/.github/renovate.json5
+++ b/.github/renovate.json5
@@ -21,14 +21,21 @@
       // Allow renovate to automatically merge PRs created for these packages. Renovate automatically checks CI/CD
       // status and will _not_ automerge PRs which have failures.
       "automerge": true,
-      // Disable minimumReleaseAge. As this setting is inherited from the default config in
-      // https://github.com/grafana/deployment_tools/blob/16231ba00eac9310d2360a2075a96b1106a02c34/ksonnet/lib/renovate-self-hosted/renovate.jsonnet#L33
-      // We need to do this because renovate cannot figure out the release date of chromium packages, as those are
-      // parsed from the HTML page at https://dl-cdn.alpinelinux.org/alpine/latest-stable/community/x86_64/.
-      "minimumReleaseAge": "",
       // Do not separate majors and minors for this group. This allows a major version bump (which chromium typically
       // has) to share the branch with a minior version bump (which alpine typically has).
       "separateMajorMinor": false,
+    },
+    {
+      // Chromium versions come from an HTML page that lists .apk files, and that page has no release dates.
+      // deployment_tools forces internalChecksFilter=strict, so Renovate marks an undateable release pending
+      // instead of ready, and with no date it stays pending forever. Grouped with alpine, the branch still
+      // looks ready, so the pending chromium upgrade is removed from it and the PR bumps alpine alone. We
+      // cannot opt out via minimumReleaseAge (same force block, not overridable), so use the Behaviour knob.
+      "matchDatasources": [
+        "custom.alpine-main",
+        "custom.alpine-community"
+      ],
+      "minimumReleaseAgeBehaviour": "timestamp-optional",
     },
   ],
   "customManagers": [

--- a/.github/workflows/renovate-validate.yaml
+++ b/.github/workflows/renovate-validate.yaml
@@ -29,3 +29,6 @@ jobs:
           persist-credentials: false
       - name: Validate Renovate Config
         uses: grafana/shared-workflows/actions/validate-renovate-config@726f1a912f45b4807774b76a6d40cbd3fb7a12c0 # validate-renovate-config/v0.1.2
+        with:
+          # The action defaults to `renovate.json` in the repo root; our config lives elsewhere.
+          path: .github/renovate.json5


### PR DESCRIPTION
Renovate has proposed no  Chromium update since 2026-05-15, every bump since was made by hand.

**Why.** Chromium versions come from an HTML page with no release dates, and `deployment_tools` forces a 3-day soak (`internalChecksFilter: 'strict'`) that requires a date as proof of age. With no date the check never passes, so chromium is [re-marked pending every run, forever](https://github.com/renovatebot/renovate/blob/23dd5682be2f38c69beb0bb0a882e0aa4d932c78/lib/workers/repository/process/lookup/filter-checks.ts#L204-L214).

**Why the alpine PR ships broken.** Both ARGs share the `Dockerfile` group; for a mixed branch Renovate [ships the ready upgrades and drops the pending ones](https://github.com/renovatebot/renovate/blob/23dd5682be2f38c69beb0bb0a882e0aa4d932c78/lib/workers/repository/updates/generate.ts#L198-L205), assuming they follow later. The follow-up never comes, and half the pair breaks the build — chromium 149 does not exist in alpine 3.24 (#170, #173).

**Fix.** `timestamp-optional` exempts undateable releases from the age proof. The old `minimumReleaseAge: ""` never worked — that key is forced upstream, repo config cannot override it. 

Ops logs (`{namespace="renovate-self-hosted"} |= "chromium-swiftshader"` on `Loki-Ops`) show it live: *"Marking 1 release(s) as pending, as they do not have a releaseTimestamp…"* — the same run wrote #173's alpine-only body 5s later. A local dry-run with the same forced settings: `main` → alpine only; this branch → both bumps.

Second commit fixes the `validate` job, broken since #155: it validated `renovate.json` in the repo root, which never existed here.
